### PR TITLE
fix dark theme headers

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -24,9 +24,11 @@ html[data-theme="light"] a:hover {
 	color: #1A1A1A;
 }
 
-html[data-theme="dark"] h1, h2, h3, h4, h5, h6 {
+html[data-theme="dark"] h1, html[data-theme="dark"] h2, html[data-theme="dark"] h3, html[data-theme="dark"] h4, html[data-theme="dark"] h5, html[data-theme="dark"] h6 {
 	color: #ffffff;
 }
+
+
 
 html[data-theme="dark"] a {
 	color: #ffffff;


### PR DESCRIPTION
The last PR accidentally colored all h2-h6 white (a problem on the light theme). This PR fixes that problem.

Is there an easier way to select all the headers in the CSS??