### PR TITLE
updates footer to use footer-items

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -76,5 +76,8 @@ table.border, .border table, .border caption, .border thead, .border tbody, .bor
 	border: thin solid gray !important;
 	text-align: center;
 }
+
+.footer-items__start {
+	width: 100%;
   }
 

--- a/docs/_templates/molssi_footer.html
+++ b/docs/_templates/molssi_footer.html
@@ -35,6 +35,10 @@
         </p>
         {% endif %}
 
+        <p class="theme-version">
+        {% trans theme_version=theme_version|e %}Built with a customized <a href="https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html">PyData Sphinx Theme</a> {{ theme_version }}.{% endtrans %}
+        </p>
+
     </div>
     <div class="col-2">
         <a href="https://nsf.gov/" target="_blank" title="Go to the NSF in a new tab">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,8 @@ html_theme_options = {
   ],
 
 	"secondary_sidebar_items": ["page-toc", "sourcelink"],
-    "footer_items": [ "molssi_footer" ],
+    "footer_start": [ "molssi_footer" ],
+    "footer_end": [],
     "icon_links": [],
 }
 


### PR DESCRIPTION
## Description
This changes `conf.py` to use `footer_start` instead of `footer_items` to address the deprecation warning. Recent changes to the footer (using `footer_start` and `footer_end`) also require us to adjust some CSS in order to have the footer look the same as before.

Addresses #13 